### PR TITLE
fix(stdin): use '-' for stdin/stdout to support WSL/Windows; pipe stdio

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,3 +187,9 @@ To release a new version, the following steps in order:
 - `npm run bump`
 - `npm run changelog`
 - `npm publish --access public`
+
+
+## Troubleshooting
+
+- WSL/Windows stdin: Earlier versions invoked Mermaid CLI with `/dev/stdin`, which can fail on WSL with `ENXIO`. This server now uses `-` for stdin/stdout (`-i -` / `-o -`) to be portable across Linux/macOS/WSL/Windows.
+- Inspector working dir: When launching via the MCP Inspector, ensure the server path resolves (e.g. `npx @modelcontextprotocol/inspector npx -y @rtuin/mcp-mermaid-validator@latest` or use an absolute path to `dist/main.js`).

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,12 +23,14 @@ server.tool(
     try {
       try {
         // Use child_process.spawn to create a process and pipe the diagram to stdin
+        // Read diagram from STDIN and write image to STDOUT.
+        // Use "-" instead of "/dev/stdin" for cross-platform compatibility (WSL, Windows, CI).
         const args = [
           "@mermaid-js/mermaid-cli",
           "-i",
-          "/dev/stdin",
+          "-", // read from stdin
           "-o",
-          "-",
+          "-", // write to stdout
           "-e",
           format,
         ];
@@ -38,7 +40,7 @@ server.tool(
           args.push("-b", "transparent");
         }
         
-        const mmdc = spawn("npx", args);
+        const mmdc = spawn("npx", args, { stdio: ["pipe", "pipe", "pipe"] });
 
         // Write the diagram to stdin and close it
         mmdc.stdin.write(diagram);


### PR DESCRIPTION
fix(stdin): use "-" for stdin/stdout to support WSL/Windows; pipe stdio

Summary
- Replace `-i /dev/stdin` with `-i -` and `-o -` when invoking @mermaid-js/mermaid-cli.
- Explicitly set `stdio: ["pipe","pipe","pipe"]` in `spawn` to preserve streams.

Why
- On WSL/Windows, using `/dev/stdin` can fail with `ENXIO: no such device or address, open '/dev/stdin'` when reading from stdin. This resulted in valid diagrams being reported as invalid.
- mermaid-cli supports `-` for stdin/stdout, which is portable across Linux/macOS/WSL/Windows.

Details
- File: src/main.ts
  - args: `-i -` for stdin, `-o -` for stdout; keep `-e` format and `-b transparent` for PNG.
  - spawn: `stdio: ["pipe","pipe","pipe"]`.
- Docs: README troubleshooting note on WSL stdin and Inspector working directory.

Validation
- WSL (Node v22.19.0):
  - `npx @modelcontextprotocol/inspector node dist/main.js --cli --method tools/list` lists tools.
  - `tools/call validateMermaid` returns success for a pie chart input and emits a PNG when `format=png`.
- Direct mmdc check:
  - `printf 'pie title NETFLIX\n"Time spent looking for movie" : 90\n"Time spent watching it" : 10\n' | npx -y @mermaid-js/mermaid-cli -i - -o - -e png > /tmp/test.png` produces a valid PNG.

Compatibility
- No breaking changes expected. Behavior remains the same on Linux/macOS; adds reliability on WSL/Windows.

Closes
- Fixes ENXIO stdin failures on WSL reported by user testing.
